### PR TITLE
Add Dockerfiles

### DIFF
--- a/DockerfileFull
+++ b/DockerfileFull
@@ -1,0 +1,17 @@
+FROM nginx:stable-alpine
+
+# install prerequisits 
+RUN apk update && apk add \
+	nodejs \
+	yarn
+	
+# create folder and copy application into folder
+RUN mkdir G5V
+COPY ./ /G5V/
+WORKDIR /G5V
+
+# build application using yarn
+RUN yarn && yarn build
+
+# copy results to nginx directory
+RUN cp -R ./dist/* /usr/share/nginx/html

--- a/DockerfileLight
+++ b/DockerfileLight
@@ -1,3 +1,2 @@
 FROM nginx:stable-alpine
 COPY ./dist /usr/share/nginx/html
-EXPOSE 80

--- a/DockerfileLight
+++ b/DockerfileLight
@@ -1,0 +1,3 @@
+FROM nginx:stable-alpine
+COPY ./dist /usr/share/nginx/html
+EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -38,6 +38,25 @@ Spins up a development server where you can make all your calls, and run it like
 
 This will generate a minified and buildable version of the website in the `dist` folder to use on a web server. In order to use history, you must have a proxy enabled, and reverse proxy enabled for the API calls. There is some setup involved, depending on your flavour of web servers, but some setup configs can be found [here](https://github.com/PhlexPlexico/G5V/wiki).
 
+### Docker Build Instructions:
+There are 2 dockerfiles included, ```DockerfileLight``` and ```DockerfileFull```.
+
+#### DockerfileLight:
+This should be used if yarn is already installed on your local machine. 
+To use it, you first need to build the application using ```yarn``` and ```yarn build```. This will create a dist folder. 
+From here, run the command ```docker build -t yourname\g5v:latest -f DockerfileLight .```
+Now, you can run your application by running ```docker container run --name g5v -p 80:80 yourname\g5v:latest```
+
+#### DockerfileFull:
+This should be used if you do not have yarn, and do not want to install it. 
+This file will install yarn in the container, build the application, and execute it. 
+To use it, run ```docker build -t yourname\g5v:latest -f DockerfileFull .```
+This can take over a minute to complete.
+Now, you can run your application by running ```docker container run --name g5v -p 80:80 yourname\g5v:latest```
+
+Please note that both of the dockerfiles still require G5API to be running on the subfolder /api/.
+Some example setup configs can be found [here](https://github.com/PhlexPlexico/G5V/wiki).
+
 ## Contribution
 Sure! If you have a knack for APIs and a penchant for JavaScript, I could always use help! Create a fork of this application, make your changes, and submit a PR. I will be using the [Issues](https://github.com/G5V/issues) page to track what calls still need to be completed.
 


### PR DESCRIPTION
This change adds 2 new files, DockerfileLight and DockerfileFull. This change also adds documentation to README.md for instructions on how to build and run the application in a docker container using the Dockerfile.

The dockerfiles base image is nginx:alpine-stable. 

The DockerfileLight does not add any extra packages on top of nginx:alpine-stable.
It takes the completed dist files and adds them into the nginx directory.

The DockerfileFull adds nodejs and yarn to the nginx:alpine-stable image.
It takes the entire application, builds it using yarn, then copies the completed dist files and adds them to the nginx directory.
This allows someone without yarn installed to deploy the docker container.