### PR TITLE
Update Dockerfiles

### DIFF
--- a/DockerfileFull
+++ b/DockerfileFull
@@ -1,4 +1,4 @@
-FROM nginx:stable-alpine
+FROM nginx:mainline-alpine
 
 ARG VUE_APP_G5V_API_URL
 RUN touch .env.production

--- a/DockerfileLight
+++ b/DockerfileLight
@@ -1,3 +1,3 @@
-FROM nginx:stable-alpine
+FROM nginx:mainline-alpine
 COPY ./dist /usr/share/nginx/html
 COPY default.conf /etc/nginx/conf.d/default.conf

--- a/DockerfileLight
+++ b/DockerfileLight
@@ -1,2 +1,3 @@
 FROM nginx:stable-alpine
 COPY ./dist /usr/share/nginx/html
+COPY default.conf /etc/nginx/nginx.conf

--- a/DockerfileLight
+++ b/DockerfileLight
@@ -1,3 +1,3 @@
 FROM nginx:stable-alpine
 COPY ./dist /usr/share/nginx/html
-COPY default.conf /etc/nginx/nginx.conf
+COPY default.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
Update both dockerfiles to nginx:mainline-alpine to resolve CVE-2021-36159 present in earlier versions of alpine
Update DockerfileLight to match changes made in DockerfileFull (404 errors on paths)