### PR TITLE
Refresh data

### DIFF
--- a/src/components/MatchesTable.vue
+++ b/src/components/MatchesTable.vue
@@ -122,11 +122,12 @@ export default {
         if (this.$route.path == "/mymatches") res = await this.GetMyMatches();
         else if (this.$route.path.includes("team"))
           res = await this.GetTeamRecentMatches(this.$route.params.id);
-        else if (this.$route.path.includes("user"))
+        else if (this.$route.path.includes("user")) {
           if (this.$route.params.id == undefined) {
             res = await this.GetUserRecentMatches(this.user.id);
           } else res = await this.GetUserRecentMatches(this.$route.params.id);
-        else if (this.$route.path.includes("season"))
+          if (res.length == 0)res = await this.GetPlayerStatRecentMatches(this.$route.params.id);
+        } else if (this.$route.path.includes("season"))
           res = await this.GetSeasonRecentMatches(this.$route.params.id);
         else res = await this.GetAllMatches();
         if (typeof res == "string") res = [];

--- a/src/components/PlayerStatInfo.vue
+++ b/src/components/PlayerStatInfo.vue
@@ -139,7 +139,7 @@ export default {
         });
       if (totalRating > 0)
         return (totalRating / this.statArray.length).toFixed(2);
-      return totalRating;
+      return 0;
     },
     isKillsLoading() {
       if (this.totalKills >= 0) return false;

--- a/src/components/PlayerStatTable.vue
+++ b/src/components/PlayerStatTable.vue
@@ -245,16 +245,6 @@ export default {
     // Template will contain v-rows/etc like on main Team page.
     this.GetMapPlayerStats();
     this.getMapString();
-    if (!this.isFinished) {
-      this.playerInterval = setInterval(async () => {
-        this.isLoading = true;
-        this.GetMapPlayerStats();
-        this.countDownTimer = 60;
-      }, 60000);
-      this.timeoutId = setInterval(() => {
-        this.countDownTimer--;
-      }, 1000);
-    }
   },
   beforeDestroy() {
     if (!this.isFinished) {
@@ -322,6 +312,16 @@ export default {
           });
         });
         if (getMatchTeamIds.end_time != null) this.isFinished = true;
+        if (!this.isFinished) {
+          this.playerInterval = setInterval(async () => {
+            this.isLoading = true;
+            this.GetMapPlayerStats();
+            this.countDownTimer = 60;
+          }, 60000);
+          this.timeoutId = setInterval(() => {
+            this.countDownTimer--;
+          }, 1000);
+        }
       } catch (error) {
         console.log("Our error: " + error);
       } finally {
@@ -335,7 +335,6 @@ export default {
         if (typeof mapStats == "string") return;
         mapStats.forEach((singleMapStat, index) => {
           this.arrMapString[index] = {};
-          console.log(singleMapStat);
           this.arrMapString[index].score =
             "Score: " +
             singleMapStat.team1_score +

--- a/src/components/PlayerStatTable.vue
+++ b/src/components/PlayerStatTable.vue
@@ -64,6 +64,7 @@
                 {{ $t("PlayerStats.RefreshForce") }}
               </v-btn>
             </div>
+            <div v-else />
           </div>
         </v-container>
         <v-data-table
@@ -240,10 +241,10 @@ export default {
       apiUrl: process.env?.VUE_APP_G5V_API_URL || "/api"
     };
   },
-  async created() {
+  created() {
     // Template will contain v-rows/etc like on main Team page.
-    await this.GetMapPlayerStats();
-    await this.getMapString();
+    this.GetMapPlayerStats();
+    this.getMapString();
     if (!this.isFinished) {
       this.playerInterval = setInterval(async () => {
         this.isLoading = true;
@@ -334,6 +335,7 @@ export default {
         if (typeof mapStats == "string") return;
         mapStats.forEach((singleMapStat, index) => {
           this.arrMapString[index] = {};
+          console.log(singleMapStat);
           this.arrMapString[index].score =
             "Score: " +
             singleMapStat.team1_score +

--- a/src/components/PlayerStatTable.vue
+++ b/src/components/PlayerStatTable.vue
@@ -235,17 +235,27 @@ export default {
   created() {
     // Template will contain v-rows/etc like on main Team page.
     this.GetMapPlayerStats();
-    // Grab new data every minute. Since a match is 1:55+40 bomb, a good time would be 1 min.
-    if (!this.isFinished)
+    this.getMapString();
+    if (!this.isFinished) {
       this.playerInterval = setInterval(async () => {
         this.isLoading = true;
         this.GetMapPlayerStats();
+        this.countDownTimer = 60;
       }, 60000);
-    this.getMapString();
+      this.timeoutId = setInterval(() => {
+        this.countDownTimer--;
+      }, 1000);
+    }
+
   },
   beforeDestroy() {
-    if (!this.isFinished && this.timeoutId != -1)
-      clearInterval(this.playerInterval);
+    if (!this.isFinished && this.timeoutId != -1) {
+      if (this.timeoutId != -1)
+        clearInterval(this.timeoutId);
+      if (this.playerInterval != -1)
+        clearInterval(this.playerInterval);
+    }
+      
   },
   methods: {
     async GetMapPlayerStats() {

--- a/src/components/PlayerStatTable.vue
+++ b/src/components/PlayerStatTable.vue
@@ -236,14 +236,14 @@ export default {
       countDownTimer: 60,
       allowRefresh: false,
       timeoutId: -1,
-      isFinished: true,
+      isFinished: false,
       apiUrl: process.env?.VUE_APP_G5V_API_URL || "/api"
     };
   },
-  created() {
+  async created() {
     // Template will contain v-rows/etc like on main Team page.
-    this.GetMapPlayerStats();
-    this.getMapString();
+    await this.GetMapPlayerStats();
+    await this.getMapString();
     if (!this.isFinished) {
       this.playerInterval = setInterval(async () => {
         this.isLoading = true;
@@ -256,7 +256,7 @@ export default {
     }
   },
   beforeDestroy() {
-    if (!this.isFinished && this.timeoutId != -1) {
+    if (!this.isFinished) {
       if (this.timeoutId != -1) clearInterval(this.timeoutId);
       if (this.playerInterval != -1) clearInterval(this.playerInterval);
     }

--- a/src/components/PlayerStatTable.vue
+++ b/src/components/PlayerStatTable.vue
@@ -49,12 +49,20 @@
           <div
             class="text-subtitle-2 mapInfo"
             v-if="
-              arrMapString[index] != null && arrMapString[index].end == null
+              arrMapString[index] != null && arrMapString[index].end != null
             "
             align="left"
           >
             <div class="text-caption" v-if="!isFinished">
               {{ $t("PlayerStats.RefreshData", { sec: countDownTimer }) }}
+              <v-btn
+                x-small
+                color="secondary"
+                @click="refreshStats"
+                :disabled="countDownTimer >= 55"
+              >
+                {{ $t("PlayerStats.RefreshForce") }}
+              </v-btn>
             </div>
           </div>
         </v-container>
@@ -246,16 +254,12 @@ export default {
         this.countDownTimer--;
       }, 1000);
     }
-
   },
   beforeDestroy() {
     if (!this.isFinished && this.timeoutId != -1) {
-      if (this.timeoutId != -1)
-        clearInterval(this.timeoutId);
-      if (this.playerInterval != -1)
-        clearInterval(this.playerInterval);
+      if (this.timeoutId != -1) clearInterval(this.timeoutId);
+      if (this.playerInterval != -1) clearInterval(this.playerInterval);
     }
-      
   },
   methods: {
     async GetMapPlayerStats() {
@@ -316,7 +320,7 @@ export default {
             }
           });
         });
-        if (getMatchTeamIds.end_time != null) this.isFinished = false;
+        if (getMatchTeamIds.end_time != null) this.isFinished = true;
       } catch (error) {
         console.log("Our error: " + error);
       } finally {
@@ -352,6 +356,21 @@ export default {
       } catch (error) {
         console.log("String error " + error);
       }
+    },
+    async refreshStats() {
+      clearInterval(this.timeoutId);
+      clearInterval(this.playerInterval);
+      this.countDownTimer = 60;
+      this.playerInterval = setInterval(async () => {
+        this.isLoading = true;
+        this.GetMapPlayerStats();
+        this.countDownTimer = 60;
+      }, 60000);
+      this.timeoutId = setInterval(() => {
+        this.countDownTimer--;
+      }, 1000);
+      this.GetMapPlayerStats();
+      return;
     }
   }
 };

--- a/src/translations/translations.json
+++ b/src/translations/translations.json
@@ -144,7 +144,7 @@
       "KAST": "KAST",
       "ContribScore": "Contribution Score",
       "MVP": "MVPs",
-      "RefreshData": "Data will refresh in {sec} seconds.",
+      "RefreshData": "Stats will refresh in {sec} seconds.",
       "RefreshForce": "Force Refresh"
     },
     "Seasons": {
@@ -312,7 +312,8 @@
       "TeamHeader": "Team",
       "MapHeader": "Map",
       "PickBan": "Pick or Ban?",
-      "SidePick": "Side Picked"
+      "SidePick": "Side Picked",
+      "RefreshData": "Veto data will refresh in {sec} seconds."
     },
     "lang": {
       "LanguageName": "English",
@@ -501,7 +502,7 @@
       "KAST": "KAST",
       "ContribScore": "貢献度",
       "MVP": "M V P",
-      "RefreshData": "データは{sec}秒で更新されます。",
+      "RefreshData": "統計情報は{sec}秒後に更新されます。",
       "RefreshForce": "強制リフレッシュ"
     },
     "Seasons": {
@@ -665,7 +666,8 @@
       "TeamHeader": "チーム",
       "MapHeader": "地図",
       "PickBan": "選ぶか禁止するか？",
-      "SidePick": "サイドピック"
+      "SidePick": "サイドピック",
+      "RefreshData": "ベトデータは{sec}秒後に更新されます。"
     },
     "lang": {
       "LanguageName": "日本語",

--- a/src/translations/translations.json
+++ b/src/translations/translations.json
@@ -144,7 +144,8 @@
       "KAST": "KAST",
       "ContribScore": "Contribution Score",
       "MVP": "MVPs",
-      "RefreshData": "Data will refresh in {sec} seconds."
+      "RefreshData": "Data will refresh in {sec} seconds.",
+      "RefreshForce": "Force Refresh"
     },
     "Seasons": {
       "Title": "Seasons/Tournaments",
@@ -500,7 +501,8 @@
       "KAST": "KAST",
       "ContribScore": "貢献度",
       "MVP": "M V P",
-      "RefreshData": "データは{sec}秒で更新されます。"
+      "RefreshData": "データは{sec}秒で更新されます。",
+      "RefreshForce": "強制リフレッシュ"
     },
     "Seasons": {
       "Title": "シーズンズ/トーナメント",

--- a/src/utils/api.vue
+++ b/src/utils/api.vue
@@ -791,6 +791,21 @@ export default {
       }
       return message;
     },
+    async GetPlayerStatRecentMatches(steamid) {
+      let res;
+      let message;
+      try {
+        res = await this.axioCall.get(
+          `${process.env?.VUE_APP_G5V_API_URL ||
+            "/api"}/playerstats/${steamid}/recent`
+        );
+        message = res.data.matches;
+      } catch (error) {
+        message = error.response.data.message;
+      }
+      console.log(message);
+      return message;
+    },
     // END PLAYER STATS
     // BEGIN MAP STATS
     async GetAllMapStats() {

--- a/src/views/User.vue
+++ b/src/views/User.vue
@@ -1,7 +1,7 @@
 <template>
   <v-card class="mx-auto">
     <v-container>
-      <v-card-title v-if="retrievedUser.id != 0">
+      <v-card-title v-if="retrievedUser.steam_id != 0">
         {{ retrievedUser.name }}
         <a
           :href="
@@ -118,13 +118,13 @@
       <v-card-title class="headline">
         {{ $t("User.Past5") }}
       </v-card-title>
-      <MatchesTable v-if="retrievedUser.id != ''" :user="retrievedUser" />
+      <MatchesTable v-if="retrievedUser.steam_id != ''" :user="retrievedUser" />
     </v-container>
     <v-container v-if="retrievedUser.id == user.id || IsAnyAdmin(user)">
       <v-card-title class="headline">
         {{ $t("User.UserMaps", { players: retrievedUser.name }) }}
       </v-card-title>
-      <MapList v-if="retrievedUser.id != -1" :user="retrievedUser" />
+      <MapList v-if="retrievedUser.id > 0" :user="retrievedUser" />
     </v-container>
     <PasswordResetDialog
       v-model="passwordResetDialog"
@@ -181,7 +181,15 @@ export default {
     this.user = await this.IsLoggedIn();
     if (this.$route.params.id == undefined) this.retrievedUser = this.user;
     else this.retrievedUser = await this.GetUserData(this.$route.params.id);
-    this.userStats = await this.GetUserPlayerStats(this.retrievedUser.steam_id);
+
+    if (this.retrievedUser.id === 0) {
+      this.userStats = await this.GetUserPlayerStats(this.$route.params.id);
+      this.retrievedUser.name = this.userStats[0].name;
+      this.retrievedUser.steam_id = this.userStats[0].steam_id;
+    } else
+      this.userStats = await this.GetUserPlayerStats(
+        this.retrievedUser.steam_id
+      );
     if (typeof this.userStats == "string") this.userStats = [];
   },
   methods: {


### PR DESCRIPTION
This PR is aimed at including some auto-pulls using `setIntervals` in two parts of the application. The first is in the player stats per map, which should allow us to poll data and view the scoreboard without having to refresh the page. After five seconds, users are allowed to force a refresh for the data, since we would like to have a bit of a wait time so spamming is not an option. 

The second point of this PR will be to try and attempt to refresh vetoes as well. However, there's not an easy way of determining if a match is complete, or has vetoes without making more API calls. So the next step is to determine if we can find a way to ensure a match is running, and has a veto process, and check to see if they are in that state. One way of doing this is to maybe create an API end point that pings the match and gets the status of the server, and the other is just using different API calls to determine if we have vetoes or not. Still need to think on this a bit more.

Closes #118 #119 